### PR TITLE
fix source_safe bug

### DIFF
--- a/src/rmt_core.c
+++ b/src/rmt_core.c
@@ -1027,6 +1027,7 @@ static struct array *write_threads_create_unsafe(rmtContext *ctx, int write_thre
         wdata->id = i;
         
         wdata->nodes_count = step;
+        pre_node = NULL;
     	for(k = begin; k < begin + step; k ++)
     	{
     		de = dictNext(di);


### PR DESCRIPTION
check write thread failed (rmt_core.c:2501) due to a small bug when source_safe set to false.