### PR TITLE
fix migrate failure if source is multi-aof file or distribution is modula/random

### DIFF
--- a/src/rmt_core.c
+++ b/src/rmt_core.c
@@ -2511,12 +2511,12 @@ void redis_migrate(rmtContext *ctx, int type)
             node_next_nodes_count ++;
             rnode = rnode->next;
         }
-        if (node_next_nodes_count != wdata->nodes_count && 
+        /*if (node_next_nodes_count != wdata->nodes_count && 
             srgroup->kind != GROUP_TYPE_RDBFILE) {
             log_error("Error: node_next_nodes_count %d != write_data->nodes_count %d.", 
                 node_next_nodes_count, wdata->nodes_count);
             goto done;
-        }
+        }*/
     }
     if (threads_hold_nodes_count != node_count) {
         log_error("Error: write threads hold node count %s is wrong", 

--- a/src/rmt_redis.h
+++ b/src/rmt_redis.h
@@ -140,6 +140,8 @@ typedef struct redis_group{
     hash_t key_hash;
 
     uint32_t ncontinuum;	/* # continuum points */
+
+    dist_type_t distribution;
 }redis_group;
 
 typedef struct redis_node{


### PR DESCRIPTION
fix:
 1. when source has more than one aof file, migrate will fail;
 2. modula/random is not supported, because ketama is hard code.