### PR TITLE
bug fix: rmt can not exit when sync redis data to rdb files

### DIFF
--- a/src/rmt_redis.c
+++ b/src/rmt_redis.c
@@ -1651,6 +1651,11 @@ static void rmtReceiveRdb(aeEventLoop *el, int fd, void *privdata, int mask)
             log_notice("Rdb file received, disconnect from the node[%s]", 
                 srnode->addr);
             notice_write_thread(srnode);    /* Let the next node begin replication */
+            int event_num = __sync_fetch_and_sub(srnode->event_num, 1);
+            log_notice("current read event number:%u", event_num - 1);
+            if (event_num == 1) {
+                aeStop(el);
+            }
             return;
         }
 

--- a/src/rmt_redis.h
+++ b/src/rmt_redis.h
@@ -174,6 +174,7 @@ typedef struct redis_node{
     long long timestamp;
 
     int sk_event;				/* used to run some task */
+    unsigned int *event_num;
 
     struct redis_node *next;	/* next redis_node to begin replication */
 }redis_node;


### PR DESCRIPTION
firstly, show my rmt.conf as follows:

    [source]
    type: single
    servers:
    -10.10.10.9:6379
    -10.10.10.10:6380

    [target]
    type: rdb file

    [common]
    listen: 10.33.80.221:8888
    step: 1
    mbuf_size: 4096
    source_safe: true
    dir: data

When rmt completes its job,  the rmt process suspended and did not halt. By rmt.log, I noticed that both the read thread read_thread_run and the write thread write_thread_run did not terminate when the rob files have been saved.

To use rmt, I clone a [fork](https://github.com/AlexStocks/redis-migrate-tool) and try to modify it to let it run by my rmt.conf. But it can not run If the value of source_safe is false.

Hope u check my code and fix this bug. Thanks.